### PR TITLE
Clear fixed heights on grad honor code table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Internal
 
+## 3.1.3
+
+### Added
+
+### Changed
+
+- Remove inline height style from grad honor code section of syllabus
+
+### Internal
+
 ## 3.1.2
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lxd-tools-react",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "main": "src/publish/index.tsx",
   "dependencies": {

--- a/src/publish/fixesAndUpdates/validations/syllabusTests.ts
+++ b/src/publish/fixesAndUpdates/validations/syllabusTests.ts
@@ -680,6 +680,15 @@ export const honorCodeCheck: CourseValidation<
         });
 
       honorCodeTd.innerHTML = gradHonorCodeHtml;
+
+      // Remove fixed heights so the table resizes naturally after the shorter grad content is inserted.
+      for (const el of [
+        gradHonorCodeTable,
+        ...Array.from(gradHonorCodeTable.querySelectorAll("tr, td")),
+      ]) {
+        (el as HTMLElement).style.removeProperty("height");
+        el.removeAttribute("height");
+      }
     } else if (course.isCareerInstitute()) {
       return testResult("not run", {
         notFailureMessage:


### PR DESCRIPTION
After inserting gradHonorCodeHtml, remove inline height styles and height attributes from the grad honor code table and all its tr/td elements so the table can resize naturally with the shorter grad content. Implements a loop that removes the CSS 'height' property and the height attribute from the table, rows, and cells.