### PR TITLE
Updating docs and workflows

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
     types: [closed]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.yaml'
 
 jobs:
   deploy_if_merged:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.yml'
+      - '**/*.yaml'
 
 permissions:
   contents: read

--- a/README.dist.md
+++ b/README.dist.md
@@ -10,6 +10,8 @@ Source repository: https://github.com/Unity-Environmental-University/lxd-tools
 
 ## Installation
 
+For most people who use this extension at Unity, it should now automatically install on your laptop. If it doesn't, you can follow the steps below:
+
 1. Clone this repository
    - If you have GitHub Desktop installed, select **Code** → **Open with GitHub Desktop**
    - Otherwise, select **Code** → **Download ZIP**, then extract the zip and place the folder somewhere easy to find

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 # This file tells the portal how to handle this repo
-edit_uri: edit/release/3.0.0/docs/
+edit_uri: edit/release/3.1.4/docs/
+site_name: LXD Extension Documentation
 
 nav:
-  - Knowledge Base: KNOWLEDGE_BASE.md
+  - User Guide: ../USER_GUIDE.md
+  - Developer Guide: ../README.md
   - Build Process: BUILD_PROCESS.md
+  - Knowledge Base: KNOWLEDGE_BASE.md


### PR DESCRIPTION
Doing this so docs and actions can be updated via PR to main without trigger a version check or deploy. This should allow us to more easily keep documentation up to date and workflows can iterate on a separate schedule to releases.