### PR TITLE
Fixed template ids in EmailLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 ### Changed
+
+### Internal
+
+## 3.1.8
+
+### Added
+
+### Changed
+- Corrected dev template course IDs in EmailLink
+
+### Changed
+
+## 3.1.7
+
+### Added
+
+### Changed
 - Hid Academic Integrity Assignment button(MakeBp.tsx)
 - Narrowed the courses that AI Literacy Assignment button shows up on in grad(PROF510, SBUS503, PROF510)
 - Updates to courseOverviewTest validation language

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lxd-tools-react",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "private": true,
   "main": "src/publish/index.tsx",
   "dependencies": {

--- a/src/publish/publishInterface/EmailLink.tsx
+++ b/src/publish/publishInterface/EmailLink.tsx
@@ -32,9 +32,9 @@ async function fetchEmailTemplate(course: Course): Promise<string> {
     let devCourseId: 7773747 | 7775658 | null = null;
 
     if (course.isUndergrad() || course.isCareerInstitute()) {
-      devCourseId = 7773747;
-    } else if (course.isGrad()) {
       devCourseId = 7775658;
+    } else if (course.isGrad()) {
+      devCourseId = 7773747;
     } else {
       throw new Error("Unsure which email to grab.");
     }


### PR DESCRIPTION
They were backwards.